### PR TITLE
Feature/libint data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ A C++ library that provides the glue code for our other libraries/modules.
 
 [![Boost Dependency](https://img.shields.io/badge/Boost-1.65.1+-000000.svg)](http://www.boost.org)
 [![Eigen3 Dependency](https://img.shields.io/badge/Eigen-3.3.4+-000000.svg)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
+[![libint2 Dependency](https://img.shields.io/badge/libint-2.3.1+-000000.svg)](https://github.com/evaleev/libint)
 
+gqcg uses the bases packaged with libint. Please set the LIBINT_DATA_PATH to the directory that contains these bases. E.g.:
+```
+export LIBINT_DATA_PATH=/usr/local/libint/2.3.1/share/basis
+```
 
 ## Installation
 To install this library:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A C++ library that provides the glue code for our other libraries/modules.
 [![Eigen3 Dependency](https://img.shields.io/badge/Eigen-3.3.4+-000000.svg)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
 [![libint2 Dependency](https://img.shields.io/badge/libint-2.3.1+-000000.svg)](https://github.com/evaleev/libint)
 
-gqcg uses the bases packaged with libint. Please set the LIBINT_DATA_PATH to the directory that contains these bases.
+gqcg uses the bases packaged with libint. Please set the `LIBINT_DATA_PATH` environment variable that contains these bases. In a default installation (of e.g. version v2.3.1), the data path is given by:
 ```
 export LIBINT_DATA_PATH=/usr/local/libint/2.3.1/share/libint/2.3.1/basis
 ```

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A C++ library that provides the glue code for our other libraries/modules.
 [![Eigen3 Dependency](https://img.shields.io/badge/Eigen-3.3.4+-000000.svg)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
 [![libint2 Dependency](https://img.shields.io/badge/libint-2.3.1+-000000.svg)](https://github.com/evaleev/libint)
 
-gqcg uses the bases packaged with libint. Please set the LIBINT_DATA_PATH to the directory that contains these bases. E.g.:
+gqcg uses the bases packaged with libint. Please set the LIBINT_DATA_PATH to the directory that contains these bases.
 ```
-export LIBINT_DATA_PATH=/usr/local/libint/2.3.1/share/basis
+export LIBINT_DATA_PATH=/usr/local/libint/2.3.1/share/libint/2.3.1/basis
 ```
 
 ## Installation


### PR DESCRIPTION
Users should set the path to the Libint bases for the test to succeed. I have added this to the README, as this is a change that each users should do to his/her .bashrc, .profile, ...